### PR TITLE
Update README.md

### DIFF
--- a/Challenges/Hardmode/Pre Era/README.md
+++ b/Challenges/Hardmode/Pre Era/README.md
@@ -538,9 +538,12 @@ YzktMyBIYXJkO2VuZXJneS5iYXNpYztlbmVyZ3kucmVnZW5lcmF0aW9uO2VuZXJneS5mbG93O3NwZWxs
 
 **C1**
 
+By: by22dgb
+
+Turn off wave streaming around wave 250
 `Import Code`
 ```
-
+QzEwLTEgSGFyZDtyZXNpc3RhbmNlLndhdGVyO3Jlc2lzdGFuY2UuZ2VuZXJpYztyZXNpc3RhbmNlLmVsZW1lbnRhbDtzaGVsbC53YXRlcjtmb3VuZGF0aW9uLmRpYW1vbmQ7YXVyYS5oZWFydHN0b3BwZXI7ZXhjaGFuZ2Uud2F0ZXI7YXR0YWNrLmxpZmVzdGVhbDthdHRhY2subXVsdGlzaG90O2F0dGFjay5zcGVlZDt0YXN0ZS5lbGVjdHJpY2l0eTthdHRhY2suZWxlY3RyaWNpdHk7Y3JpdC5lbGVjdHJpY2l0eURtZztidXJzdC5lbGVjdHJpY2l0eTtjb3JlLm1hZ25ldGlj
 ```
 **C2**
 


### PR DESCRIPTION
add c10-1

PR's must use the format already given
For actual PR formatting, just give us a small description of what changes you made. Anything else is not needed.

Pre Era Mode Rules:

they can't use over the top stats 
they can't require post era software 
obviously no post era modules 
they should be consistent

If you are post era, you should disable some of your stats to make it consistant for era if you're not doing hardmode

