### PR TITLE
c13-3/c15-3 + fast c7-4

### DIFF
--- a/Challenges/Hardmode/Pre Era/README.md
+++ b/Challenges/Hardmode/Pre Era/README.md
@@ -402,21 +402,13 @@ YzctMyBoYXJkO2ZvdW5kYXRpb24uZ3Jhbml0ZTtzaGVsbC5uYXR1cmU7ZXhjaGFuZ2UubmF0dXJlO2Zv
 ```
 **C4**
 
-Made by: Lunaa.620
+Made by: fireball
 
-Can be done without Generic Resistance, but you will get very close to dying, and could maybe even die in some cases
+If you're using this for Normal Mode, you will need to disable Basic, Nature and Universal resistances in Town Stats.
 
-Enable AI and start it before the run (F4)
-
-**Turn Off:** Wave Streaming
-
-`Blueprint Import Code`
+`Import Code`
 ```
-YzctNDtlbmVyZ3kuYmFzaWM7ZW5lcmd5LnJlZ2VuZXJhdGlvbjtzcGVsbC5yZXNwb25zZS5uZXV0cmFsO2VuZXJneS5yZWN5Y2xpbmc7ZW5lcmd5Lm1vb247Z2lmdC5mb3Jlc3Q7Z2lmdC5kZXNlcnQ7Zm91bmRhdGlvbi5kaWFtb25kO2ZvdW5kYXRpb24uZ3Jhbml0ZTtleGNoYW5nZS5uZXV0cmFsO3Jlc2lzdGFuY2UubmV1dHJhbDtmb3VuZGF0aW9uLnN0ZWVsO2ZvdW5kYXRpb24ubWFyYmxlO3JlZ2VuZXJhdGlvbi5yZWxhdGl2ZTtyZXNpc3RhbmNlLmdlbmVyaWM7cmVmbGVjdC53aW5jZTtjYXQucG93ZXI=
-```
-`Facility AI Import Code`
-```
-BGM3LTQBAAAABndha2V1cAAAAAACAAAAF3Rvd2VyLm1vZHVsZS51c2VpbnN0YW50CGNvbnN0YW50AgEAAAAMZ2VuZXJpYy5nb3RvCGNvbnN0YW50AgEAAAA=
+RclBCoAgEAXQq4T7XAVBXqA7RAvTXw4MQ4waRXT3aNX2vdssXLErSclmaCYT+rZrRq/RRayQDKtYGaE4nCF52WAFtajnH/C9UqByuZwIHG0VOqDZs5mfFw==
 ```
 **C5**
 

--- a/Challenges/Hardmode/Pre Era/README.md
+++ b/Challenges/Hardmode/Pre Era/README.md
@@ -803,11 +803,13 @@ QzEzLTIgSE07ZGVmZW5zZS5kYWlnb3BhcnJ5O2dpZnQuY2hhb3M7Zm91bmRhdGlvbi5ncmFuaXRlO2Zv
 
 No Accel
 
-By: Yoshi128986 
+By: fireball
+
+If you're using this for Normal Mode, you will need to disable Basic, Water, Air and Light resistances in Town Stats.
 
 `Import Code`
 ```
-XZDBTgQhDIZfZTN3iSae5OrBdzAeOtAdmmUKaYvrxPjuYnaIjhfS/+On/cvnNOeGVYhNp6fT6xQe7u8eTy8g0WvqpzoK6MEMwsVpRYxDrC0baSo2wFwa/3pvytVUkOnjH12AYCBaK1rTIQUqxTMJejUkJhcSEGN0M+Tsg5D1SikMf0SwdO1BvJaWXc/8jmrEy82LGYMJBbLteV383EQP0Bv0OQeyN/6L9owHpjWDph+0Ih97zqX0KYzNBPKurmAoex1BLoyqHhll2cZCTcCdpRv8uX9TBKPC/c76w216+/oG
+NchBCgIxDAXQqwzdW5DZ2Qt4B3ER2982GDKSZpyFeHcH1N3jvcJNVjyM1Uc4TZeQj/Nhns5kJZE75XssIO8bj55Gh0gktp82cvwt3LqnuqxayHnR2IyUHcnQoLBvGmTHE6mgQgf2qILs4fr+AA==
 ```
 **C4**
 
@@ -935,11 +937,11 @@ MTUtMiBIYXJkO3NoaWVsZC51bml2ZXJzYWw7ZGVmZW5zZS5yZWZsZWN0
 
 No Accel
 
-By: Yoshi128986
+By: fireball
 
 `Import Code`
 ```
-XZDBTgQhDIZfZTN3iSae5OrBdzAeOtAdmmUKaYvrxPjuYnaIjhfS/+On/cvnNOeGVYhNp6fT6xQe7u8eTy8g0WvqpzoK6MEMwsVpRYxDrC0baSo2wFwa/3pvytVUkOnjH12AYCBaK1rTIQUqxTMJejUkJhcSEGN0M+Tsg5D1SikMf0SwdO1BvJaWXc/8jmrEy82LGYMJBbLteV383EQP0Bv0OQeyN/6L9owHpjWDph+0Ih97zqX0KYzNBPKurmAoex1BLoyqHhll2cZCTcCdpRv8uX9TBKPC/c76w216+/oG
+PY/BasMwDIZfpeQ+wxi7zNce+g5jB8VWYhFHMZLcUkbfvYKQHL9f+tCv/2GsHZsQmw4/l98hfX5/fF1uIDmCGaQljKCUDtCGeE4EGuWJBI9g7dVIy2anu3VOGLVV0BIg38Hx9GltaF0PzAhWHu5HNaEFg1vMvm6ghoGxm0CNScgOuK7zzntJXyOmkAqQex7WGrX4LxrIa8w0neYOnemOohgnL5rBaGO3zFCeEbpAmGRTi8go83M/Mvy93g==
 ```
 **C4**
 
@@ -963,7 +965,7 @@ XZA9bsMwDIWvEnivgA5ZqrVD71B0oCXaIqxIAn+cBkXvXjeGkqYLwe/xgXrU1zBmw8ZUVIaXw/sQno9P
 
 No Accel
 
-By: Yoshi128986
+By: fireball
 
 `Import Code`
 ```

--- a/Challenges/Hardmode/Pre Era/README.md
+++ b/Challenges/Hardmode/Pre Era/README.md
@@ -402,14 +402,37 @@ YzctMyBoYXJkO2ZvdW5kYXRpb24uZ3Jhbml0ZTtzaGVsbC5uYXR1cmU7ZXhjaGFuZ2UubmF0dXJlO2Zv
 ```
 **C4**
 
+Made by: Lunaa.620
+
+Can be done without Generic Resistance, but you will get very close to dying, and could maybe even die in some cases
+
+Enable AI and start it before the run (F4)
+
+**Turn Off:** Wave Streaming
+
+`Blueprint Import Code`
+```
+YzctNDtlbmVyZ3kuYmFzaWM7ZW5lcmd5LnJlZ2VuZXJhdGlvbjtzcGVsbC5yZXNwb25zZS5uZXV0cmFsO2VuZXJneS5yZWN5Y2xpbmc7ZW5lcmd5Lm1vb247Z2lmdC5mb3Jlc3Q7Z2lmdC5kZXNlcnQ7Zm91bmRhdGlvbi5kaWFtb25kO2ZvdW5kYXRpb24uZ3Jhbml0ZTtleGNoYW5nZS5uZXV0cmFsO3Jlc2lzdGFuY2UubmV1dHJhbDtmb3VuZGF0aW9uLnN0ZWVsO2ZvdW5kYXRpb24ubWFyYmxlO3JlZ2VuZXJhdGlvbi5yZWxhdGl2ZTtyZXNpc3RhbmNlLmdlbmVyaWM7cmVmbGVjdC53aW5jZTtjYXQucG93ZXI=
+```
+`Facility AI Import Code`
+```
+BGM3LTQBAAAABndha2V1cAAAAAACAAAAF3Rvd2VyLm1vZHVsZS51c2VpbnN0YW50CGNvbnN0YW50AgEAAAAMZ2VuZXJpYy5nb3RvCGNvbnN0YW50AgEAAAA=
+```
+
+
+**Alternative solution**.
+
 Made by: fireball
 
 If you're using this for Normal Mode, you will need to disable Basic, Nature and Universal resistances in Town Stats.
+
+Might be fixed in the future.
 
 `Import Code`
 ```
 RclBCoAgEAXQq4T7XAVBXqA7RAvTXw4MQ4waRXT3aNX2vdssXLErSclmaCYT+rZrRq/RRayQDKtYGaE4nCF52WAFtajnH/C9UqByuZwIHG0VOqDZs5mfFw==
 ```
+
 **C5**
 
 Made By: rimfire_, gen1code


### PR DESCRIPTION
Updated c15-3 and c13-3. The previous versions (which were just c10-4) were dying.
*Yes, c15-3 and c15-6 are the same.*
12 hours later: updated c7-4. Now it's done in 40 seconds.

PR's must use the format already given
For actual PR formatting, just give us a small description of what changes you made. Anything else is not needed.

Pre Era Mode Rules:

they can't use over the top stats 
they can't require post era software 
obviously no post era modules 
they should be consistent

If you are post era, you should disable some of your stats to make it consist**e**nt for era if you're not doing hardmode
~~[yoshi fix the template, why does it have a typo that I highlighted (it was **a** originally)]~~

